### PR TITLE
Load YAML spec to persistent term

### DIFF
--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,0 +1,92 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Sample API
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:4000/api
+paths:
+  /posts:
+    get:
+      summary: List all posts
+      operationId: listPosts
+      tags:
+        - posts
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 50)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: A paged array of posts
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Posts"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /posts/{slug}:
+    get:
+      summary: Info for a specific post
+      operationId: showPostbySlug
+      tags:
+        - posts
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: The slug of the post to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Posts"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Post:
+      required:
+        - title
+        - description
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+    Posts:
+      type: array
+      items:
+        $ref: "#/components/schemas/Post"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/lib/easy_api.ex
+++ b/lib/easy_api.ex
@@ -15,4 +15,9 @@ defmodule EasyApi do
   def hello do
     :world
   end
+
+  def load_spec(filename \\ "api_spec.yaml") do
+    {:ok, spec} = YamlElixir.read_from_file(filename)
+    :persistent_term.put(EasyApi.Spec, Map.get(spec, "paths"))
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule EasyApi.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:yaml_elixir, "~> 2.4.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "yamerl": {:hex, :yamerl, "0.8.0", "8214cfe16bbabe5d1d6c14a14aea11c784b9a21903dd6a7c74f8ce180adae5c7", [:rebar3], [], "hexpm"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.4.0", "2f444abc3c994c902851fde56b6a9cb82895c291c05a0490a289035c2e62ae71", [:mix], [{:yamerl, "~> 0.7", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
Add fun `load_spec/1` which loads YAML spec file to persistent term.

In the future, the `load_spec/1` fun will be called automatically to load spec initially.